### PR TITLE
feat: allow dependent workflow to define custom labels

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,30 @@ inputs:
     description: 'The GITHUB_TOKEN secret'
     required: true
     default: ${{ github.token }}
+  label-a11y:
+    description: 'Label used to identify accessibility issues that should be categorized'
+    required: false
+    default: "A11Y"
+  label-blocker:
+    description: 'Label used to identify blocker issues'
+    required: false
+    default: "Blocker"
+  label-critical:
+    description: 'Label used to identify critical issues'
+    required: false
+    default: "Critical"
+  label-serious:
+    description: 'Label used to identify serious issues'
+    required: false
+    default: "Serious"
+  label-moderate:
+    description: 'Label used to identify moderate issues'
+    required: false
+    default: "Moderate"
+  label-production:
+    description: 'Label used to identify issues that exist in production'
+    required: false
+    default: "Production"
 runs:
   using: node16
   main: dist/index.js


### PR DESCRIPTION
_Merge at the same time as https://github.com/dequelabs/action-a11y-issue-labeler/pull/9._

### 1. Support for custom labels

Adds support for dependent workflows to define their own custom labels for things like severity levels (e.g, "Critical") and deployment status (e.g. "Production") where collisions with predefined labels in the dependent GitHub projects are most likely.

### 2. More forgiving config file parsing

Resolves #2 by allowing the `a11y-metrics` file to use either a `.yml` or `.yaml` extension.